### PR TITLE
fix unexpected MOUNTPATH change when $KSU = false

### DIFF
--- a/system/bin/lhroot
+++ b/system/bin/lhroot
@@ -26,7 +26,7 @@ fi
 
 # Magisk Mod Directories
 MODPATH=/data/adb/modules/$ID
-$KSU && MOUNTPATH=$(dirname $MODPATH) || MOUNTPATH="$(magisk --path)/.magisk/modules"
+$KSU && MOUNTPATH=$(dirname $MODPATH) || $KSU && MOUNTPATH="$(magisk --path)/.magisk/modules"
 MODDIR="$MOUNTPATH/$ID"
 [ ! -d $MODDIR ] && { echo "Module not detected!"; exit 1; }
 


### PR DESCRIPTION
```bash
$KSU && MOUNTPATH=$(dirname $MODPATH) || MOUNTPATH="$(magisk --path)/.magisk/modules"
```

will accidentally change MOUNTPATH if $KSU = false.

$KSU = false make the whole expression '$KSU && MOUNTPATH=$(dirname $MODPATH)' = false.

then shell will execute 'MOUNTPATH="$(magisk --path)/.magisk/modules" ' 

that is accidentally changed Magisk users' MOUNTPATH

so add the "$KSU &&" after the "||" is absolutely patch to reach maintainers original meanings

 (as the "&&"'s priority higher than "||")